### PR TITLE
v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.3.2 (2020-07-04)
+1. Upgrade `ocore` to v0.3.12
+2. Upgrade `aa-testkit` to v0.3.3
+3. mocha bootload updated
+
+### Fixes
+1. Fixed example agent
+
 ## v0.3.1 (2020-06-25)
 1. Upgrade `ocore` to v0.3.11
 2. Oscript 2.0 autocomplete and documentation

--- a/client/testing/examples/example.aa
+++ b/client/testing/examples/example.aa
@@ -2,13 +2,10 @@
 	bounce_fees: { base: 10000 },
 	messages: [
 		{
-			app: 'payment',
-			payload: {
-				asset: 'base',
-				outputs: [
-					{address: "{trigger.address}", amount: "{trigger.output[[asset=base]] - 1000}"}
-				]
-			}
+			app: 'state',
+			state: `{
+				response['result'] = trigger.data.a + trigger.data.b;
+			}`
 		}
 	]
 }

--- a/client/testing/examples/example.test.oscript.js
+++ b/client/testing/examples/example.test.oscript.js
@@ -29,7 +29,7 @@ describe('Check simple AA', function () {
 
 		const aliceBalance = await this.network.wallet.alice.getBalance()
 		expect(aliceBalance.base.pending).to.be.equal(0)
-		expect(aliceBalance.base.stable).to.be.equal(989756)
+		expect(aliceBalance.base.stable).to.be.equal(989626)
 	}).timeout(60000)
 
 	it('Trigger AA', async () => {

--- a/client/testing/mochaBootload.js
+++ b/client/testing/mochaBootload.js
@@ -2,6 +2,7 @@
 const path = require('path')
 const chai = require('chai')
 const expect = chai.expect
+const deepEqualInAnyOrder = require('deep-equal-in-any-order')
 const { Testkit } = require('aa-testkit')
 const { Network, Nodes, Utils } = Testkit({
 	TESTDATA_DIR: path.join(process.env.VSCODE_WORKSPACE_DIR, 'testdata')
@@ -14,18 +15,20 @@ global.Network = Network
 global.Nodes = Nodes
 global.Utils = Utils
 
+chai.use(deepEqualInAnyOrder)
+
 chai.use((_chai, utils) => {
 	chai.Assertion.addProperty('validAddress', function () {
 		const address = utils.flag(this, 'object')
 		const negate = utils.flag(this, 'negate')
 		const check = Utils.isValidAddress(address)
-		new chai.Assertion(check).to.be.equal(!negate)
+		new chai.Assertion(check).to.be.equal(!negate, !check && `'${JSON.stringify(address)}' is not valid address`)
 	})
 
 	chai.Assertion.addProperty('validUnit', function () {
 		const unit = utils.flag(this, 'object')
 		const negate = utils.flag(this, 'negate')
 		const check = Utils.isValidBase64(unit, 44) && unit.endsWith('=')
-		new chai.Assertion(check).to.be.equal(!negate)
+		new chai.Assertion(check).to.be.equal(!negate, !check && `'${JSON.stringify(unit)}' is not valid unit`)
 	})
 })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Oscript support for writing Autonomous Agents in VS Code",
 	"author": "Obyte",
 	"license": "MIT",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"icon": "images/icon.png",
 	"repository": {
 		"type": "git",
@@ -96,6 +96,7 @@
 		"axios": "^0.19.2",
 		"chai": "^4.2.0",
 		"chokidar": "^3.3.1",
+		"deep-equal-in-any-order": "^1.0.27",
 		"lodash": "^4.17.15",
 		"mocha": "^7.1.1",
 		"obyte": "^0.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,23 +3,23 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.3.tgz#324bcfd8d35cd3d47dae18cde63d752086435e9a"
-  integrity sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
-    "@babel/highlight" "^7.10.3"
+    "@babel/highlight" "^7.10.4"
 
-"@babel/helper-validator-identifier@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
-  integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
-"@babel/highlight@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.3.tgz#c633bb34adf07c5c13156692f5922c81ec53f28d"
-  integrity sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.10.3"
+    "@babel/helper-validator-identifier" "^7.10.4"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -184,13 +184,14 @@
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
 "aa-testkit@git+https://github.com/valyakin/aa-testkit.git":
-  version "0.3.2"
-  resolved "git+https://github.com/valyakin/aa-testkit.git#234da6f79e5b7ed964f50fd92f26bfe211b36e24"
+  version "0.3.3"
+  resolved "git+https://github.com/valyakin/aa-testkit.git#cd4781f904b16ca6c57d757e5fa01185e8f90643"
   dependencies:
     bitcore-lib "^0.13.14"
     bitcore-mnemonic "~1.0.0"
     config "^3.2.2"
     crypto "^1.0.1"
+    deep-equal-in-any-order "^1.0.27"
     headless-obyte "git+https://github.com/byteball/headless-obyte"
     joi "^14.3.1"
     lodash "^4.17.15"
@@ -201,6 +202,7 @@
     obyte-witness "git+https://github.com/byteball/obyte-witness"
     ocore "git+https://github.com/byteball/ocore"
     secp256k1 "^3.1.0"
+    timekeeper "^2.2.0"
     uniqid "^5.0.3"
     yargs "^14.0.0"
 
@@ -250,9 +252,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   integrity sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==
 
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
+  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -561,9 +563,9 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 binary-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
-  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
 bindings@^1.5.0, bindings@~1.5.0:
   version "1.5.0"
@@ -806,7 +808,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.5.0:
+buffer@^5.5.0, buffer@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
   integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
@@ -1302,6 +1304,14 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
+deep-equal-in-any-order@^1.0.27:
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.27.tgz#607c4250368f3f95dddb07cc768ef5428132c16e"
+  integrity sha512-yxZ1zYvaiZidcpprBq5hZdbiWNzNXQtcDjc10R2iMfoCgYx6oIdwkPrIaXbcvZkk6spsJvG/C1nRyVTcI748Jg==
+  dependencies:
+    lodash.mapvalues "^4.6.0"
+    sort-any "^1.1.21"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -1667,9 +1677,9 @@ eslint-plugin-es@^1.4.1:
     regexpp "^2.0.1"
 
 eslint-plugin-import@^2.17.3:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
-  integrity sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
+  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
@@ -2426,7 +2436,7 @@ he@1.2.0:
 
 "headless-obyte@git+https://github.com/byteball/headless-obyte":
   version "0.1.9"
-  resolved "git+https://github.com/byteball/headless-obyte#cddd667504885879ff624746a264db1cfef92165"
+  resolved "git+https://github.com/byteball/headless-obyte#512e96142717005bdeb229daef6e30a4aa1e9f80"
   dependencies:
     bitcore-lib "^0.13.14"
     bitcore-mnemonic "~1.0.0"
@@ -2436,8 +2446,8 @@ he@1.2.0:
 
 "headless-obyte@git+https://github.com/byteball/headless-obyte.git":
   version "0.1.9"
-  uid cddd667504885879ff624746a264db1cfef92165
-  resolved "git+https://github.com/byteball/headless-obyte.git#cddd667504885879ff624746a264db1cfef92165"
+  uid "512e96142717005bdeb229daef6e30a4aa1e9f80"
+  resolved "git+https://github.com/byteball/headless-obyte.git#512e96142717005bdeb229daef6e30a4aa1e9f80"
   dependencies:
     bitcore-lib "^0.13.14"
     bitcore-mnemonic "~1.0.0"
@@ -3067,9 +3077,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 level-codec@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-9.0.1.tgz#042f4aa85e56d4328ace368c950811ba802b7247"
-  integrity sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-9.0.2.tgz#fd60df8c64786a80d44e63423096ffead63d8cbc"
+  integrity sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==
+  dependencies:
+    buffer "^5.6.0"
 
 level-errors@^2.0.0, level-errors@~2.0.0:
   version "2.0.1"
@@ -3197,6 +3209,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+  integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
 
 lodash.once@^4.0.0:
   version "4.1.1"
@@ -3852,7 +3869,7 @@ object.values@^1.1.1:
 
 "obyte-explorer@git+https://github.com/byteball/obyte-explorer":
   version "0.1.0"
-  resolved "git+https://github.com/byteball/obyte-explorer#115eacff37841ed60dbfb7d51e953b9b7c4b6693"
+  resolved "git+https://github.com/byteball/obyte-explorer#c307ad614129dda7850724a0ac60d264127380fc"
   dependencies:
     async "^2.1.5"
     ejs "^2.6.1"
@@ -3864,7 +3881,7 @@ object.values@^1.1.1:
 
 "obyte-hub@git+https://github.com/byteball/obyte-hub":
   version "0.1.5"
-  resolved "git+https://github.com/byteball/obyte-hub#a07e3a5d08e648980421ea60c441047ac5d3be42"
+  resolved "git+https://github.com/byteball/obyte-hub#f6e448781a86c968f5ed7d62245f5dbcd3dcb5f6"
   dependencies:
     apn "^2.2.0"
     obyte-relay "git+https://github.com/byteball/obyte-relay.git"
@@ -3884,9 +3901,9 @@ object.values@^1.1.1:
     ocore "git+https://github.com/byteball/ocore.git"
 
 obyte@^0.1.7:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/obyte/-/obyte-0.1.8.tgz#e7d0ed29cd982ae5e57041f1d188ec58859c0996"
-  integrity sha512-io05rjQ2FX6XriKT/rB9Jp3K2WxJHeqeIsXka5k9TbtKPQ7cC+QIpE73jsgo1Jj0h8yvCMi0iSMdB5DXY5nsUQ==
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/obyte/-/obyte-0.1.9.tgz#daaed81dacef189bf560895f682c434db332b579"
+  integrity sha512-cEvqeXJ3cIs0L21ALSrI4bAvXbj/Zi8n4GdeqLPEIGW+WXdXbCog4XF0bMjofd9mBXJ7Ct1Gwi8wS8yzVdyFcQ==
   dependencies:
     babel-runtime "^6.26.0"
     create-hash "^1.2.0"
@@ -3896,8 +3913,8 @@ obyte@^0.1.7:
     ws "^7.1.0"
 
 "ocore@git+https://github.com/byteball/ocore":
-  version "0.3.11"
-  resolved "git+https://github.com/byteball/ocore#67e1fa4515bee83c47eff39fcd0e4df96bceec68"
+  version "0.3.12"
+  resolved "git+https://github.com/byteball/ocore#79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
   dependencies:
     async "^2.6.1"
     bitcore-mnemonic "~1.0.0"
@@ -3917,9 +3934,9 @@ obyte@^0.1.7:
     ws "^1.0.1"
 
 "ocore@git+https://github.com/byteball/ocore.git":
-  version "0.3.11"
-  uid "67e1fa4515bee83c47eff39fcd0e4df96bceec68"
-  resolved "git+https://github.com/byteball/ocore.git#67e1fa4515bee83c47eff39fcd0e4df96bceec68"
+  version "0.3.12"
+  uid "79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
+  resolved "git+https://github.com/byteball/ocore.git#79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
   dependencies:
     async "^2.6.1"
     bitcore-mnemonic "~1.0.0"
@@ -4217,9 +4234,9 @@ posix-character-classes@^0.1.0:
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 prebuild-install@^5.0.0:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.4.tgz#6982d10084269d364c1856550b7d090ea31fa293"
-  integrity sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.5.tgz#e7e71e425298785ea9d22d4f958dbaccf8bb0e1b"
+  integrity sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^2.0.3"
@@ -4639,9 +4656,9 @@ run-queue@^1.0.0, run-queue@^1.0.3:
     aproba "^1.1.1"
 
 rxjs@^6.4.0:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
   dependencies:
     tslib "^1.9.0"
 
@@ -4916,6 +4933,13 @@ socks@1.1.10:
   dependencies:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
+
+sort-any@^1.1.21:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/sort-any/-/sort-any-1.1.22.tgz#09be6ec1194dfe19d32d9a50a99023b3ff431f22"
+  integrity sha512-RDDFA8jZTeYQgH7icQQV+O6ZMC3ZmNLIx8EBbqQPM3J/Wi0iuHrdd/BIr8V6mUlaYEL8RFK2wP+G3q1OiiviWQ==
+  dependencies:
+    lodash "^4.17.15"
 
 source-list-map@^2.0.0:
   version "2.0.1"
@@ -5282,6 +5306,11 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+timekeeper@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.2.0.tgz#9645731fce9e3280a18614a57a9d1b72af3ca368"
+  integrity sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==
 
 timers-browserify@^2.0.4:
   version "2.0.11"


### PR DESCRIPTION
## v0.3.2 (2020-07-04)
1. Upgrade `ocore` to v0.3.12
2. Upgrade `aa-testkit` to v0.3.3
3. mocha bootload updated

### Fixes
1. Fixed example agent