### PR TITLE
v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.3.3 (2020-07-14)
+1. Upgrade `aa-testkit` to v0.3.5
+2. Test cleanup procedure
+
 ## v0.3.2 (2020-07-04)
 1. Upgrade `ocore` to v0.3.12
 2. Upgrade `aa-testkit` to v0.3.3

--- a/client/testing/index.js
+++ b/client/testing/index.js
@@ -16,6 +16,7 @@ function testCurrentFile () {
 
 		const mochaRuntimePath = require.resolve('mocha/lib/cli/cli.js')
 		const mochaArgs = [
+			'--exit',
 			'--bail',
 			'--slow',
 			'20000',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Oscript support for writing Autonomous Agents in VS Code",
 	"author": "Obyte",
 	"license": "MIT",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"icon": "images/icon.png",
 	"repository": {
 		"type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,8 +184,8 @@
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
 "aa-testkit@git+https://github.com/valyakin/aa-testkit.git":
-  version "0.3.3"
-  resolved "git+https://github.com/valyakin/aa-testkit.git#cd4781f904b16ca6c57d757e5fa01185e8f90643"
+  version "0.3.5"
+  resolved "git+https://github.com/valyakin/aa-testkit.git#1f8e715b6635a9b0c2f0e020a2bb5a7d46a840c9"
   dependencies:
     bitcore-lib "^0.13.14"
     bitcore-mnemonic "~1.0.0"
@@ -196,7 +196,6 @@
     joi "^14.3.1"
     lodash "^4.17.15"
     mkdirp "^0.5.1"
-    mockdate "^2.0.5"
     obyte-explorer "git+https://github.com/byteball/obyte-explorer"
     obyte-hub "git+https://github.com/byteball/obyte-hub"
     obyte-witness "git+https://github.com/byteball/obyte-witness"
@@ -247,9 +246,9 @@ ajv-errors@^1.0.0:
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.0.tgz#5c894537098785926d71e696114a53ce768ed773"
-  integrity sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
+  integrity sha512-KWcq3xN8fDjSB+IMoh2VaXVhRI0BBGxoYp3rx7Pkb6z0cFjYR9Q9l4yZqqals0/zsioCmocC5H6UvsGD4MoIBA==
 
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
   version "6.12.3"
@@ -3226,9 +3225,9 @@ lodash@3.x.x, lodash@=3.10.1:
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.6.1:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@3.0.0:
   version "3.0.0"
@@ -3512,11 +3511,6 @@ mocha@^7.1.1:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
-mockdate@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.5.tgz#70c6abf9ed4b2dae65c81dfc170dd1a5cec53620"
-  integrity sha512-ST0PnThzWKcgSLyc+ugLVql45PvESt3Ul/wrdV/OPc/6Pr8dbLAIJsN1cIp41FLzbN+srVTNIRn+5Cju0nyV6A==
-
 moment@^2.17.1:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
@@ -3642,9 +3636,9 @@ negotiator@0.6.2:
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 neo-async@^2.5.0, neo-async@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
-  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -3869,7 +3863,7 @@ object.values@^1.1.1:
 
 "obyte-explorer@git+https://github.com/byteball/obyte-explorer":
   version "0.1.0"
-  resolved "git+https://github.com/byteball/obyte-explorer#c307ad614129dda7850724a0ac60d264127380fc"
+  resolved "git+https://github.com/byteball/obyte-explorer#dd8157b50ee5358deea6428a906cebbf049d7d69"
   dependencies:
     async "^2.1.5"
     ejs "^2.6.1"
@@ -3881,7 +3875,7 @@ object.values@^1.1.1:
 
 "obyte-hub@git+https://github.com/byteball/obyte-hub":
   version "0.1.5"
-  resolved "git+https://github.com/byteball/obyte-hub#f6e448781a86c968f5ed7d62245f5dbcd3dcb5f6"
+  resolved "git+https://github.com/byteball/obyte-hub#daa729ed010a74e803844dd3518b84656f729c49"
   dependencies:
     apn "^2.2.0"
     obyte-relay "git+https://github.com/byteball/obyte-relay.git"
@@ -3889,7 +3883,7 @@ object.values@^1.1.1:
 
 "obyte-relay@git+https://github.com/byteball/obyte-relay.git":
   version "0.1.0"
-  resolved "git+https://github.com/byteball/obyte-relay.git#9d3eb965d97b1985bc86aff8b40e82b1629ddc28"
+  resolved "git+https://github.com/byteball/obyte-relay.git#7e95534c3e0dbbb21feb215641464ff2bf4224f3"
   dependencies:
     ocore "git+https://github.com/byteball/ocore.git"
 
@@ -3914,7 +3908,7 @@ obyte@^0.1.7:
 
 "ocore@git+https://github.com/byteball/ocore":
   version "0.3.12"
-  resolved "git+https://github.com/byteball/ocore#79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
+  resolved "git+https://github.com/byteball/ocore#9e2db1b3b7e7310399f28454987b0f7496c21410"
   dependencies:
     async "^2.6.1"
     bitcore-mnemonic "~1.0.0"
@@ -3935,8 +3929,8 @@ obyte@^0.1.7:
 
 "ocore@git+https://github.com/byteball/ocore.git":
   version "0.3.12"
-  uid "79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
-  resolved "git+https://github.com/byteball/ocore.git#79222b0e8200fa3aa3cff297c96178f1dcaac3ca"
+  uid "9e2db1b3b7e7310399f28454987b0f7496c21410"
+  resolved "git+https://github.com/byteball/ocore.git#9e2db1b3b7e7310399f28454987b0f7496c21410"
   dependencies:
     async "^2.6.1"
     bitcore-mnemonic "~1.0.0"
@@ -5237,9 +5231,9 @@ tar-fs@^2.0.0:
     tar-stream "^2.0.0"
 
 tar-stream@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
-  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.3.tgz#1e2022559221b7866161660f118255e20fa79e41"
+  integrity sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==
   dependencies:
     bl "^4.0.1"
     end-of-stream "^1.4.1"
@@ -5784,9 +5778,9 @@ ws@^1.0.1:
     ultron "1.0.x"
 
 ws@^7.1.0, ws@^7.1.2:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
-  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
+  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
 
 ws@~6.1.0:
   version "6.1.4"


### PR DESCRIPTION
1. Upgrade `aa-testkit` to v0.3.5
2. Test cleanup procedure